### PR TITLE
feat: Link slack channel with support for adding triage slack channel.

### DIFF
--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -50,7 +50,7 @@ create table slack_event(
 
 
 -- mapped as per raw conversation item from Slack API reponse.
--- for conversation list with reference to tenant.
+-- with reference to tenant.
 create table insync_slack_channel(
   tenant_id varchar(255) not null, -- reference to tenant.
   context_team_id varchar(255) not null,
@@ -85,4 +85,18 @@ create table insync_slack_channel(
   updated_at timestamp default current_timestamp,
   constraint insync_slack_channel_tenant_id_fkey foreign key (tenant_id) references tenant(tenant_id), 
   constraint insync_slack_channel_tenant_id_id_key unique (tenant_id, id)
+);
+
+create table linked_slack_channel(
+  tenant_id varchar(255) not null, -- reference to tenant.
+  linked_slack_channel_id varchar(255) not null,
+  slack_channel_ref varchar(255) not null, -- reference to Slack channel(id).
+  slack_channel_name varchar(255) null, -- reference to Slack channel(name).
+  triage_slack_channel_ref varchar(255) not null, -- reference to Slack channel(id).
+  triage_slack_channel_name varchar(255) null, -- reference to Slack channel(name).
+  created_at timestamp default current_timestamp,
+  updated_at timestamp default current_timestamp,
+  constraint linked_slack_channel_id_pkey primary key (linked_slack_channel_id),
+  constraint linked_slack_channel_tenant_id_fkey foreign key (tenant_id) references tenant(tenant_id),
+  constraint linked_slack_channel_tenant_id_slack_channel_ref_key unique (tenant_id, slack_channel_ref)
 );

--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -1,15 +1,33 @@
+-- Please follow the naming convention for consistency.
+
+-- {tablename}_{columnname(s)}_{suffix}
+
+-- where the suffix is one of the following:
+
+-- pkey for a Primary Key constraint
+-- key for a Unique constraint
+-- excl for an Exclusion constraint
+-- idx for any other kind of index
+-- fkey for a Foreign key
+-- check for a Check constraint
+
+-- Standard suffix for sequences is
+-- seq for all sequences
+
+-- Thanks.
+-- --------------------------------------------------
+
 -- represents the tenant table.
 create table tenant(
   tenant_id varchar(255) not null,
   name varchar(512) not null,
   slack_team_ref varchar(255) null,
-  
   created_at timestamp default current_timestamp,
   updated_at timestamp default current_timestamp,
-
-  constraint tenant_idx primary key (tenant_id),
-  constraint slack_team_ref_unq unique (slack_team_ref)
+  constraint tenant_tenant_id_pkey primary key (tenant_id),
+  constraint tenant_slack_team_ref_key unique (slack_team_ref)
 );
+
 
 -- represents the slack event table.
 create table slack_event(
@@ -22,44 +40,49 @@ create table slack_event(
   api_app_id varchar(255) null,
   token varchar(255) null,
   payload jsonb,
-  
   is_ack boolean not null default false,
-  
   created_at timestamp default current_timestamp,
   updated_at timestamp default current_timestamp,
-
-  constraint slack_event_idx primary key (event_id),
-  constraint fk_tenant_id foreign key (tenant_id) references tenant(tenant_id),
-  constraint slack_event_ref_unq unique (slack_event_ref)
+  constraint slack_event_event_id_pkey primary key (event_id),
+  constraint slack_event_tenant_id_fkey foreign key (tenant_id) references tenant(tenant_id),
+  constraint slack_event_slack_event_ref_key unique (slack_event_ref) -- unique across Slack workspaces. As per docs.
 );
 
--- represents the synced slack channel
--- create table synced_channel(
---   channel_id varchar(255) not null,
---   tenant_id varchar(255) not null,
---   slack_channel_id varchar(255) not null,
---   context_team_id varchar(255) not null,
---   created bigint not null,
---   creator varchar(255) not null,
---   is_archived boolean not null,
---   is_channel boolean not null,
---   is_ext_shared boolean not null,
---   is_general boolean not null,
---   is_group boolean not null,
---   is_im boolean not null,
---   is_member boolean not null,
---   is_mpim boolean not null,
---   is_org_shared boolean not null,
---   is_pending_ext_shared boolean not null,
---   is_private boolean not null,
---   is_shared boolean not null,
---   name varchar(255) not null,
---   name_normalized varchar(255) not null,
---   updated bigint not null,
---   synced_ts bigint not null,
---   created_at timestamp default current_timestamp,
---   updated_at timestamp default current_timestamp,
 
---   constraint synced_channel_idx primary key (channel_id),
---   constraint fk_tenant_id foreign key (tenant_id) references tenant(tenant_id)
--- );
+-- mapped as per raw conversation item from Slack API reponse.
+-- for conversation list with reference to tenant.
+create table insync_slack_channel(
+  tenant_id varchar(255) not null, -- reference to tenant.
+  context_team_id varchar(255) not null,
+  created bigint not null,
+  creator varchar(255) not null,
+  id varchar(255) not null,
+  is_archived boolean not null,
+  is_channel boolean not null,
+  is_ext_shared boolean not null,
+  is_general boolean not null,
+  is_group boolean not null,
+  is_im boolean not null,
+  is_member boolean not null,
+  is_mpim boolean not null,
+  is_org_shared boolean not null,
+  is_pending_ext_shared boolean not null,
+  is_private boolean not null,
+  is_shared boolean not null,
+  name varchar(255) not null,
+  name_normalized varchar(255) not null,
+  num_members bigint not null,
+  parent_conversation varchar(255) null,
+  pending_connected_team_ids text[] null,
+  pending_shared text[] null,
+  previous_names text[] null,
+  purpose jsonb null,
+  shared_team_ids text[] null,
+  topic jsonb null,
+  unlinked bigint null,
+  updated bigint not null,
+  created_at timestamp default current_timestamp,
+  updated_at timestamp default current_timestamp,
+  constraint insync_slack_channel_tenant_id_fkey foreign key (tenant_id) references tenant(tenant_id), 
+  constraint insync_slack_channel_tenant_id_id_key unique (tenant_id, id)
+);

--- a/src/adapters/db/adapters.py
+++ b/src/adapters/db/adapters.py
@@ -2,10 +2,14 @@ import attrs
 from sqlalchemy.engine.base import Engine
 
 from src.adapters.db import engine
-from src.domain.models import SlackEvent, Tenant
+from src.domain.models import InSyncSlackChannelItem, SlackEvent, Tenant
 
-from .entities import SlackEventDBEntity, TenantDBEntity
-from .respositories import SlackEventRepository, TenantRepository
+from .entities import InSyncSlackChannelDBEntity, SlackEventDBEntity, TenantDBEntity
+from .respositories import (
+    InSyncChannelRepository,
+    SlackEventRepository,
+    TenantRepository,
+)
 
 
 class SlackEventDBAdapter:
@@ -93,4 +97,94 @@ class TenantDBAdapter:
                 return None
             else:
                 result = self._map_to_domain(tenant_entity)
+        return result
+
+    async def get_by_id(self, tenant_id: str) -> Tenant:
+        async with self.engine.begin() as conn:
+            tenant_entity = await TenantRepository(conn).get_by_id(tenant_id)
+            result = self._map_to_domain(tenant_entity)
+        return result
+
+
+class InSyncChannelDBAdapter:
+    def __init__(self, engine: Engine = engine) -> None:
+        self.engine = engine
+
+    def _map_to_db_entity(
+        self, insync_slack_channel: InSyncSlackChannelItem
+    ) -> InSyncSlackChannelDBEntity:
+        return InSyncSlackChannelDBEntity(
+            tenant_id=insync_slack_channel.tenant_id,
+            context_team_id=insync_slack_channel.context_team_id,
+            created=insync_slack_channel.created,
+            creator=insync_slack_channel.creator,
+            id=insync_slack_channel.id,
+            is_archived=insync_slack_channel.is_archived,
+            is_channel=insync_slack_channel.is_channel,
+            is_ext_shared=insync_slack_channel.is_ext_shared,
+            is_general=insync_slack_channel.is_general,
+            is_group=insync_slack_channel.is_group,
+            is_im=insync_slack_channel.is_im,
+            is_member=insync_slack_channel.is_member,
+            is_mpim=insync_slack_channel.is_mpim,
+            is_org_shared=insync_slack_channel.is_org_shared,
+            is_pending_ext_shared=insync_slack_channel.is_pending_ext_shared,
+            is_private=insync_slack_channel.is_private,
+            is_shared=insync_slack_channel.is_shared,
+            name=insync_slack_channel.name,
+            name_normalized=insync_slack_channel.name_normalized,
+            num_members=insync_slack_channel.num_members,
+            parent_conversation=insync_slack_channel.parent_conversation,
+            pending_connected_team_ids=insync_slack_channel.pending_connected_team_ids,
+            pending_shared=insync_slack_channel.pending_shared,
+            previous_names=insync_slack_channel.previous_names,
+            purpose=insync_slack_channel.purpose,
+            shared_team_ids=insync_slack_channel.shared_team_ids,
+            topic=insync_slack_channel.topic,
+            unlinked=insync_slack_channel.unlinked,
+            updated=insync_slack_channel.updated,
+            updated_at=insync_slack_channel.updated_at,
+            created_at=insync_slack_channel.created_at,
+        )
+
+    def _map_to_domain(self, sync_channel_entity: InSyncSlackChannelDBEntity):
+        return InSyncSlackChannelItem(
+            tenant_id=sync_channel_entity.tenant_id,
+            context_team_id=sync_channel_entity.context_team_id,
+            created=sync_channel_entity.created,
+            creator=sync_channel_entity.creator,
+            id=sync_channel_entity.id,
+            is_archived=sync_channel_entity.is_archived,
+            is_channel=sync_channel_entity.is_channel,
+            is_ext_shared=sync_channel_entity.is_ext_shared,
+            is_general=sync_channel_entity.is_general,
+            is_group=sync_channel_entity.is_group,
+            is_im=sync_channel_entity.is_im,
+            is_member=sync_channel_entity.is_member,
+            is_mpim=sync_channel_entity.is_mpim,
+            is_org_shared=sync_channel_entity.is_org_shared,
+            is_pending_ext_shared=sync_channel_entity.is_pending_ext_shared,
+            is_private=sync_channel_entity.is_private,
+            is_shared=sync_channel_entity.is_shared,
+            name=sync_channel_entity.name,
+            name_normalized=sync_channel_entity.name_normalized,
+            num_members=sync_channel_entity.num_members,
+            parent_conversation=sync_channel_entity.parent_conversation,
+            pending_connected_team_ids=sync_channel_entity.pending_connected_team_ids,
+            pending_shared=sync_channel_entity.pending_shared,
+            previous_names=sync_channel_entity.previous_names,
+            purpose=sync_channel_entity.purpose,
+            shared_team_ids=sync_channel_entity.shared_team_ids,
+            topic=sync_channel_entity.topic,
+            unlinked=sync_channel_entity.unlinked,
+            updated=sync_channel_entity.updated,
+            updated_at=sync_channel_entity.updated_at,
+            created_at=sync_channel_entity.created_at,
+        )
+
+    async def save(self, insync_slack_channel: InSyncSlackChannelItem):
+        db_entity = self._map_to_db_entity(insync_slack_channel)
+        async with self.engine.begin() as conn:
+            sync_channel_entity = await InSyncChannelRepository(conn).save(db_entity)
+            result = self._map_to_domain(sync_channel_entity)
         return result

--- a/src/adapters/db/entities.py
+++ b/src/adapters/db/entities.py
@@ -59,3 +59,14 @@ class InSyncSlackChannelDBEntity(DBEntity):
     updated: int
     created_at: datetime | None = None  # db timestamp
     updated_at: datetime | None = None  # db timestamp
+
+
+class LinkedSlackChannelDBEntity(DBEntity):
+    tenant_id: str
+    linked_slack_channel_id: str | None = None  # primary key
+    slack_channel_ref: str
+    slack_channel_name: str | None = None
+    triage_slack_channel_ref: str
+    triage_slack_channel_name: str | None = None
+    created_at: datetime | None = None  # db timestamp
+    updated_at: datetime | None = None  # db timestamp

--- a/src/adapters/db/entities.py
+++ b/src/adapters/db/entities.py
@@ -27,28 +27,35 @@ class SlackEventDBEntity(DBEntity):
     is_ack: bool = False
 
 
-# class SyncedChannelDBEntity(BaseModel):
-#     channel_id: str | None = None  # primary key
-#     tenant_id: str  # fk reference to Tenant
-#     slack_channel_ref: str
-#     context_team_id: str
-#     created: int
-#     creator: str
-#     is_archived: bool
-#     is_channel: bool
-#     is_ext_shared: bool
-#     is_general: bool
-#     is_group: bool
-#     is_im: bool
-#     is_member: bool
-#     is_mpim: bool
-#     is_org_shared: bool
-#     is_pending_ext_shared: bool
-#     is_private: bool
-#     is_shared: bool
-#     name: str
-#     name_normalized: str
-#     updated: int
-#     synced_ts: int
-#     created_at: datetime | None = None  # db timestamp
-#     updated_at: datetime | None = None  # db timestamp
+class InSyncSlackChannelDBEntity(DBEntity):
+    tenant_id: str
+    context_team_id: str
+    created: int
+    creator: str
+    id: str
+    is_archived: bool
+    is_channel: bool
+    is_ext_shared: bool
+    is_general: bool
+    is_group: bool
+    is_im: bool
+    is_member: bool
+    is_mpim: bool
+    is_org_shared: bool
+    is_pending_ext_shared: bool
+    is_private: bool
+    is_shared: bool
+    name: str
+    name_normalized: str
+    num_members: int
+    parent_conversation: str | None = None
+    pending_connected_team_ids: list[str] | None = None
+    pending_shared: list[str] | None = None
+    previous_names: list[str] | None = None
+    purpose: dict | None = None
+    shared_team_ids: list[str] | None = None
+    topic: dict | None = None
+    unlinked: int | None = None
+    updated: int
+    created_at: datetime | None = None  # db timestamp
+    updated_at: datetime | None = None  # db timestamp

--- a/src/adapters/db/exceptions.py
+++ b/src/adapters/db/exceptions.py
@@ -1,2 +1,6 @@
 class DBIntegrityException(Exception):
     pass
+
+
+class DBNotFoundException(Exception):
+    pass

--- a/src/adapters/db/respositories.py
+++ b/src/adapters/db/respositories.py
@@ -3,11 +3,12 @@ import json
 import random
 import string
 
+from sqlalchemy import Connection
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import text
 
-from .entities import SlackEventDBEntity, TenantDBEntity
-from .exceptions import DBIntegrityException
+from .entities import InSyncSlackChannelDBEntity, SlackEventDBEntity, TenantDBEntity
+from .exceptions import DBIntegrityException, DBNotFoundException
 
 
 class BaseRepository:
@@ -36,14 +37,14 @@ class AbstractTenantRepository(abc.ABC):
 
 
 class TenantRepository(AbstractTenantRepository, BaseRepository):
-    def __init__(self, connection):
+    def __init__(self, connection: Connection) -> None:
         self.conn = connection
 
     async def find_by_slack_team_ref(
         self, slack_team_ref: str
     ) -> TenantDBEntity | None:
         query = """
-            select tenant_id, name, created_at, updated_at
+            select tenant_id, slack_team_ref, name, created_at, updated_at
             from tenant
             where slack_team_ref = :slack_team_ref
         """
@@ -56,7 +57,7 @@ class TenantRepository(AbstractTenantRepository, BaseRepository):
 
     async def find_by_id(self, tenant_id: str) -> TenantDBEntity | None:
         query = """
-            select tenant_id, name, created_at, updated_at
+            select tenant_id, slack_team_ref, name, created_at, updated_at
             from tenant
             where tenant_id = :tenant_id
         """
@@ -66,6 +67,12 @@ class TenantRepository(AbstractTenantRepository, BaseRepository):
         if result is None:
             return None
         return TenantDBEntity(**result)
+
+    async def get_by_id(self, tenant_id: str) -> TenantDBEntity:
+        tenant = await self.find_by_id(tenant_id)
+        if tenant is None:
+            raise DBNotFoundException(f"tenant with id `{tenant_id}` not found")
+        return tenant
 
     async def _upsert(self, tenant: TenantDBEntity) -> TenantDBEntity:
         query = """
@@ -84,7 +91,7 @@ class TenantRepository(AbstractTenantRepository, BaseRepository):
                 name = :name
                 slack_team_ref = :slack_team_ref
                 updated_at = now()
-            returning tenant_id, name, slack_team_ref, created_at, updated_at
+            returning tenant_id, slack_team_ref name, created_at, updated_at
         """
         parameters = {
             "tenant_id": tenant.tenant_id,
@@ -118,7 +125,7 @@ class TenantRepository(AbstractTenantRepository, BaseRepository):
                 :name,
                 :slack_team_ref
             )
-            returning tenant_id, name, slack_team_ref, created_at, updated_at
+            returning tenant_id, slack_team_ref, name, created_at, updated_at
         """
         parameters = {
             "tenant_id": tenant_id,
@@ -160,7 +167,7 @@ class AbstractSlackEventRepository(abc.ABC):
 
 
 class SlackEventRepository(AbstractSlackEventRepository, BaseRepository):
-    def __init__(self, connection) -> None:
+    def __init__(self, connection: Connection) -> None:
         self.conn = connection
 
     async def find_by_slack_event_ref(self, slack_event_ref: str):
@@ -301,3 +308,162 @@ class SlackEventRepository(AbstractSlackEventRepository, BaseRepository):
         if slack_event.event_id is None:
             return await self._insert(slack_event)
         return await self._upsert(slack_event)
+
+
+class AbstractInSyncChannelRepository(abc.ABC):
+    @abc.abstractmethod
+    async def save(self, channel: InSyncSlackChannelDBEntity) -> dict:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def find_by_tenant_id_id(self, tenant_id: str, id: str) -> dict | None:
+        raise NotImplementedError
+
+
+class InSyncChannelRepository(AbstractInSyncChannelRepository, BaseRepository):
+    def __init__(self, connection: Connection) -> None:
+        self.conn = connection
+
+    async def find_by_tenant_id_id(self, tenant_id: str, id: str) -> dict | None:
+        query = """
+            select tenant_id, context_team_id, created, creator, id, is_archived,
+            is_channel, is_ext_shared, is_general, is_group, is_im, is_member, is_mpim,
+            is_org_shared, is_pending_ext_shared, is_private, is_shared, name,
+            name_normalized, num_members, parent_conversation,
+            pending_connected_team_ids, pending_shared, previous_names, purpose,
+            shared_team_ids, topic, unlinked, updated, created_at, updated_at
+            from insync_slack_channel
+            where tenant_id = :tenant_id and id = :id
+        """
+        parameters = {"tenant_id": tenant_id, "id": id}
+        rows = await self.conn.execute(statement=text(query), parameters=parameters)
+        result = rows.mappings().first()
+        if result is None:
+            return None
+        return InSyncSlackChannelDBEntity(**result)
+
+    async def save(self, insync_channel: InSyncSlackChannelDBEntity):
+        query = """
+            insert into insync_slack_channel (
+                tenant_id, context_team_id, created, creator, id, is_archived,
+                is_channel, is_ext_shared, is_general, is_group, is_im, is_member,
+                is_mpim, is_org_shared, is_pending_ext_shared, is_private, is_shared,
+                name, name_normalized, num_members, parent_conversation,
+                pending_connected_team_ids, pending_shared, previous_names, purpose,
+                shared_team_ids, topic, unlinked, updated
+            )
+            values (
+                :tenant_id, :context_team_id, :created, :creator, :id, :is_archived,
+                :is_channel, :is_ext_shared, :is_general, :is_group, :is_im, :is_member,
+                :is_mpim, :is_org_shared, :is_pending_ext_shared, :is_private,
+                :is_shared, :name, :name_normalized, :num_members, :parent_conversation,
+                :pending_connected_team_ids, :pending_shared, :previous_names, :purpose,
+                :shared_team_ids, :topic, :unlinked, :updated
+            )
+            on conflict (tenant_id, id) do update set
+                tenant_id = :tenant_id,
+                context_team_id = :context_team_id,
+                created = :created,
+                creator = :creator,
+                id = :id,
+                is_archived = :is_archived,
+                is_channel = :is_channel,
+                is_ext_shared = :is_ext_shared,
+                is_general = :is_general,
+                is_group = :is_group,
+                is_im = :is_im,
+                is_member = :is_member,
+                is_mpim = :is_mpim,
+                is_org_shared = :is_org_shared,
+                is_pending_ext_shared = :is_pending_ext_shared,
+                is_private = :is_private,
+                is_shared = :is_shared,
+                name = :name,
+                name_normalized = :name_normalized,
+                num_members = :num_members,
+                parent_conversation = :parent_conversation,
+                pending_connected_team_ids = :pending_connected_team_ids,
+                pending_shared = :pending_shared,
+                previous_names = :previous_names,
+                purpose = :purpose,
+                shared_team_ids = :shared_team_ids,
+                topic = :topic,
+                unlinked = :unlinked,
+                updated = :updated,
+                updated_at = now()
+            returning tenant_id, context_team_id, created, creator, id, is_archived,
+                is_channel, is_ext_shared, is_general, is_group, is_im, is_member,
+                is_mpim, is_org_shared, is_pending_ext_shared, is_private, is_shared,
+                name, name_normalized, num_members, parent_conversation,
+                pending_connected_team_ids, pending_shared, previous_names, purpose,
+                shared_team_ids, topic, unlinked, updated, created_at, updated_at
+        """
+        purpose = (
+            json.dumps(insync_channel.purpose)
+            if isinstance(insync_channel.purpose, dict)
+            else None
+        )
+        topic = (
+            json.dumps(insync_channel.topic)
+            if isinstance(insync_channel.topic, dict)
+            else None
+        )
+        parameters = {
+            "tenant_id": insync_channel.tenant_id,
+            "context_team_id": insync_channel.context_team_id,
+            "created": insync_channel.created,
+            "creator": insync_channel.creator,
+            "id": insync_channel.id,
+            "is_archived": insync_channel.is_archived,
+            "is_channel": insync_channel.is_channel,
+            "is_ext_shared": insync_channel.is_ext_shared,
+            "is_general": insync_channel.is_general,
+            "is_group": insync_channel.is_group,
+            "is_im": insync_channel.is_im,
+            "is_member": insync_channel.is_member,
+            "is_mpim": insync_channel.is_mpim,
+            "is_org_shared": insync_channel.is_org_shared,
+            "is_pending_ext_shared": insync_channel.is_pending_ext_shared,
+            "is_private": insync_channel.is_private,
+            "is_shared": insync_channel.is_shared,
+            "name": insync_channel.name,
+            "name_normalized": insync_channel.name_normalized,
+            "num_members": insync_channel.num_members,
+            "parent_conversation": insync_channel.parent_conversation,
+            "pending_connected_team_ids": insync_channel.pending_connected_team_ids
+            if isinstance(insync_channel.pending_connected_team_ids, list)
+            and len(insync_channel.pending_connected_team_ids)
+            else None,
+            "pending_shared": insync_channel.pending_shared
+            if isinstance(insync_channel.pending_shared, list)
+            and len(insync_channel.pending_shared)
+            else None,
+            "previous_names": insync_channel.previous_names
+            if isinstance(insync_channel.previous_names, list)
+            and len(insync_channel.previous_names)
+            else None,
+            "purpose": purpose,
+            "shared_team_ids": insync_channel.shared_team_ids
+            if isinstance(insync_channel.shared_team_ids, list)
+            and len(insync_channel.shared_team_ids)
+            else None,
+            "topic": topic,
+            "unlinked": insync_channel.unlinked,
+            "updated": insync_channel.updated,
+        }
+
+        try:
+            # query = text(query)
+            # rows = await self.conn.execute(query.bindparams(**parameters))
+            rows = await self.conn.execute(statement=text(query), parameters=parameters)
+            result = rows.mappings().first()
+        except IntegrityError as e:
+            # We are raising `DBIntegrityException` here
+            # to maintain common exception handling for database related
+            # exceptions, this makes sure that we are not leaking
+            # database related exceptions to the downstream layers
+            #
+            # Having custom exceptions for database related exceptions
+            # also helps us to have a better control over the error handling.
+            raise DBIntegrityException(e)
+        return InSyncSlackChannelDBEntity(**result)

--- a/src/adapters/rpc/__init__.py
+++ b/src/adapters/rpc/__init__.py
@@ -1,0 +1,12 @@
+# from slack_sdk import WebClient
+
+# from src.config import SLACK_BOT_OAUTH_TOKEN
+
+# #
+# #  Sanchit Rk
+# #  sanchitrrk@gmail.com
+# #
+# #  TODO:
+# #  for now we are reading from env, but ideally this will some how be injected
+# #  from the tenant context
+# slack_web_client = WebClient(token=SLACK_BOT_OAUTH_TOKEN)

--- a/src/adapters/rpc/exceptions.py
+++ b/src/adapters/rpc/exceptions.py
@@ -1,0 +1,6 @@
+class SlackAPIResponseException(Exception):
+    pass
+
+
+class SlackAPIException(Exception):
+    pass

--- a/src/adapters/rpc/ext.py
+++ b/src/adapters/rpc/ext.py
@@ -1,3 +1,86 @@
-class SlackConnectorAPI:
-    def send_message(self, channel, message):
-        print(f"Sending message to {channel.channel_id}: {message}")
+from typing import List
+
+from pydantic import BaseModel, ConfigDict
+from slack_sdk import WebClient
+
+from src.config import SLACK_BOT_OAUTH_TOKEN
+from src.domain.models import ForSyncSlackConversationItem
+from src.logger import logger
+
+from .exceptions import SlackAPIException, SlackAPIResponseException
+
+#
+#  Sanchit Rk
+#  sanchitrrk@gmail.com
+#  
+#  TODO:
+#  for now we are reading from env, but ideally this will some how be injected
+#  from the tenant context
+slack_web_client = WebClient(token=SLACK_BOT_OAUTH_TOKEN)
+
+
+class SlackConversationItemResponse(BaseModel):
+    model_config: ConfigDict = ConfigDict(str_to_lower=True)
+
+    context_team_id: str
+    created: int
+    creator: str
+    id: str
+    is_archived: bool
+    is_channel: bool
+    is_ext_shared: bool
+    is_general: bool
+    is_group: bool
+    is_im: bool
+    is_member: bool
+    is_mpim: bool
+    is_org_shared: bool
+    is_pending_ext_shared: bool
+    is_private: bool
+    is_shared: bool
+    name: str
+    name_normalized: str
+    num_members: int
+    parent_conversation: str | None = None
+    pending_connected_team_ids: list[str] = []
+    pending_shared: list[str] = []
+    previous_names: list[str] = []
+    purpose: dict
+    shared_team_ids: list[str] = []
+    topic: dict
+    unlinked: int
+    updated: int
+
+
+class SlackWebAPIConnector:
+    def __init__(self, client: WebClient = slack_web_client) -> None:
+        self.client = client
+
+    def get_conversation_list(
+        self, types: str = "public_channels"
+    ) -> List[ForSyncSlackConversationItem]:
+        logger.info(f"invoked `get_conversation_list` for args: {types}")
+        try:
+            response = self.client.conversations_list(types=types)
+        except SlackAPIException as e:
+            logger.error(f"slack API error: {e}")
+
+        logger.info("slack got response!")
+        results = []
+        if response.get("ok"):
+            for channel in response.get("channels", []):
+                conversation_item_response = SlackConversationItemResponse(**channel)
+                conversation_item_response_dict = (
+                    conversation_item_response.model_dump()
+                )
+                conversation_item = ForSyncSlackConversationItem.from_dict(
+                    conversation_item_response_dict
+                )
+                results.append(conversation_item)
+        else:
+            error = response.get("error", "unknown")
+            logger.error(f"slack connector API error with slack error code: {error}")
+            raise SlackAPIResponseException(
+                f"slack connector API error with slack error code: {error}"
+            )
+        return results

--- a/src/adapters/web/__init__.py
+++ b/src/adapters/web/__init__.py
@@ -4,7 +4,7 @@ from sqlalchemy.sql import text
 from src.adapters.db import engine
 from src.logger import logger
 
-from .routers import events, onboardings
+from .routers import events, onboardings, tenants
 
 app = FastAPI()
 
@@ -17,6 +17,11 @@ app.include_router(
 app.include_router(
     onboardings.router,
     prefix="/onboardings",
+)
+
+app.include_router(
+    tenants.router,
+    prefix="/tenants",
 )
 
 

--- a/src/adapters/web/routers/ops.py
+++ b/src/adapters/web/routers/ops.py
@@ -1,0 +1,2 @@
+# These routes shall be specific for ops and management for Tenants.TabError
+# I'm not sure what routes to include for here for now.

--- a/src/adapters/web/routers/tenants.py
+++ b/src/adapters/web/routers/tenants.py
@@ -1,10 +1,14 @@
 from typing import List
 
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, constr
 
-from src.application.commands import TenantSyncChannelCommand
-from src.application.repr import insync_slack_channel_item_repr
+from src.application.commands import LinkSlackChannelCommand, TenantSyncChannelCommand
+from src.application.repr import (
+    insync_slack_channel_item_repr,
+    linked_slack_channel_repr,
+)
+from src.services.channel import ChannelLinkService
 from src.services.tenant import TenantChannelSyncService
 
 router = APIRouter()
@@ -13,6 +17,12 @@ router = APIRouter()
 class TenantSyncChannelsRequestBody(BaseModel):
     tenant_id: str
     types: List[str]
+
+
+class LinkChannelRequestBody(BaseModel):
+    tenant_id: str
+    slack_channel_ref: constr(min_length=3, max_length=255, to_lower=True)
+    triage_slack_channel_ref: constr(min_length=3, max_length=255, to_lower=True)
 
 
 @router.post("/channels/sync/")
@@ -25,3 +35,17 @@ async def sync_channels(request_body: TenantSyncChannelsRequestBody):
     results = await channel_sync_services.sync_now(command=command)
     response = (insync_slack_channel_item_repr(r) for r in results)
     return response
+
+
+@router.post("/channels/link/")
+async def link_channel(request_body: LinkChannelRequestBody):
+    command = LinkSlackChannelCommand(
+        tenant_id=request_body.tenant_id,
+        slack_channel_ref=request_body.slack_channel_ref,
+        triage_slack_channel_ref=request_body.triage_slack_channel_ref,
+    )
+
+    channel_link_service = ChannelLinkService()
+    result = await channel_link_service.link(command=command)
+    linked_slack_channel = linked_slack_channel_repr(result)
+    return linked_slack_channel

--- a/src/adapters/web/routers/tenants.py
+++ b/src/adapters/web/routers/tenants.py
@@ -3,7 +3,8 @@ from typing import List
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from src.application.repr import for_sync_slack_conversation_item_repr
+from src.application.commands import TenantSyncChannelCommand
+from src.application.repr import insync_slack_channel_item_repr
 from src.services.tenant import TenantChannelSyncService
 
 router = APIRouter()
@@ -16,10 +17,11 @@ class TenantSyncChannelsRequestBody(BaseModel):
 
 @router.post("/channels/sync/")
 async def sync_channels(request_body: TenantSyncChannelsRequestBody):
-    tenant_id = request_body.tenant_id
-    print(f"invoking sync for tenant_id: {tenant_id}")
-    types = request_body.types
+    command = TenantSyncChannelCommand(
+        tenant_id=request_body.tenant_id,
+        types=request_body.types,
+    )
     channel_sync_services = TenantChannelSyncService()
-    results = channel_sync_services.sync_with_sync(types=types)
-    response = (for_sync_slack_conversation_item_repr(item) for item in results)
+    results = await channel_sync_services.sync_now(command=command)
+    response = (insync_slack_channel_item_repr(r) for r in results)
     return response

--- a/src/adapters/web/routers/tenants.py
+++ b/src/adapters/web/routers/tenants.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from src.application.repr import for_sync_slack_conversation_item_repr
+from src.services.tenant import TenantChannelSyncService
+
+router = APIRouter()
+
+
+class TenantSyncChannelsRequestBody(BaseModel):
+    tenant_id: str
+    types: List[str]
+
+
+@router.post("/channels/sync/")
+async def sync_channels(request_body: TenantSyncChannelsRequestBody):
+    tenant_id = request_body.tenant_id
+    print(f"invoking sync for tenant_id: {tenant_id}")
+    types = request_body.types
+    channel_sync_services = TenantChannelSyncService()
+    results = channel_sync_services.sync_with_sync(types=types)
+    response = (for_sync_slack_conversation_item_repr(item) for item in results)
+    return response

--- a/src/application/commands/__init__.py
+++ b/src/application/commands/__init__.py
@@ -12,3 +12,8 @@ class SlackEventCallBackCommand(BaseModel):
     event: dict
     event_ts: int
     payload: dict
+
+
+class TenantSyncChannelCommand(BaseModel):
+    tenant_id: str
+    types: list[str] | None = None

--- a/src/application/commands/__init__.py
+++ b/src/application/commands/__init__.py
@@ -17,3 +17,9 @@ class SlackEventCallBackCommand(BaseModel):
 class TenantSyncChannelCommand(BaseModel):
     tenant_id: str
     types: list[str] | None = None
+
+
+class LinkSlackChannelCommand(BaseModel):
+    tenant_id: str
+    slack_channel_ref: constr(min_length=3, max_length=255, to_lower=True)
+    triage_slack_channel_ref: constr(min_length=3, max_length=255, to_lower=True)

--- a/src/application/repr/__init__.py
+++ b/src/application/repr/__init__.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-from src.domain.models import InSyncSlackChannelItem, SlackEvent
+from src.domain.models import InSyncSlackChannelItem, LinkedSlackChannel, SlackEvent
 
 
 class TenantRepr(BaseModel):
@@ -12,7 +12,8 @@ class TenantRepr(BaseModel):
 
 
 class SlackCallBackEventRepr(BaseModel):
-    id: str
+    event_id: str
+    is_ack: bool
 
 
 class InSyncSlackChannelItemRepr(BaseModel):
@@ -37,10 +38,28 @@ class InSyncSlackChannelItemRepr(BaseModel):
     created_at: datetime
 
 
+class SlackChannelRepr(BaseModel):
+    channel_ref: str
+    channel_name: str
+
+
+class TriageSlackChannelRepr(SlackChannelRepr):
+    pass
+
+
+class LinkedSlackChannelRepr(BaseModel):
+    linked_slack_channel_id: str
+    slack_channel: SlackChannelRepr
+    triage_slack_channel: TriageSlackChannelRepr
+
+
 def slack_callback_event_repr(
     slack_event: SlackEvent,
 ) -> SlackCallBackEventRepr:
-    pass
+    return SlackCallBackEventRepr(
+        event_id=slack_event.event_id,
+        is_ack=slack_event.is_ack,
+    )
 
 
 def insync_slack_channel_item_repr(
@@ -69,4 +88,21 @@ def insync_slack_channel_item_repr(
         updated=item.updated,
         updated_at=item.updated_at,
         created_at=item.created_at,
+    )
+
+
+def linked_slack_channel_repr(item: LinkedSlackChannel):
+    slack_channel = SlackChannelRepr(
+        channel_ref=item.slack_channel_ref,
+        channel_name=item.slack_channel_name,
+    )
+    triage_channel = item.triage_channel
+    triage_slack_channel = TriageSlackChannelRepr(
+        channel_ref=triage_channel.slack_channel_ref,
+        channel_name=triage_channel.slack_channel_name,
+    )
+    return LinkedSlackChannelRepr(
+        linked_slack_channel_id=item.linked_slack_channel_id,
+        slack_channel=slack_channel,
+        triage_slack_channel=triage_slack_channel,
     )

--- a/src/application/repr/__init__.py
+++ b/src/application/repr/__init__.py
@@ -1,6 +1,8 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
-from src.domain.models import ForSyncSlackConversationItem, SlackEvent
+from src.domain.models import InSyncSlackChannelItem, SlackEvent
 
 
 class TenantRepr(BaseModel):
@@ -13,7 +15,7 @@ class SlackCallBackEventRepr(BaseModel):
     id: str
 
 
-class InSyncSlackConversationItemRepr(BaseModel):
+class InSyncSlackChannelItemRepr(BaseModel):
     id: str
     name: str
     created: int
@@ -31,6 +33,8 @@ class InSyncSlackConversationItemRepr(BaseModel):
     is_shared: bool
     topic: dict
     updated: int
+    updated_at: datetime
+    created_at: datetime
 
 
 def slack_callback_event_repr(
@@ -39,13 +43,13 @@ def slack_callback_event_repr(
     pass
 
 
-def for_sync_slack_conversation_item_repr(
-    item: ForSyncSlackConversationItem,
-) -> InSyncSlackConversationItemRepr:
+def insync_slack_channel_item_repr(
+    item: InSyncSlackChannelItem,
+) -> InSyncSlackChannelItemRepr:
     topic = {
         "value": item.topic.get("value", ""),
     }
-    return InSyncSlackConversationItemRepr(
+    return InSyncSlackChannelItemRepr(
         id=item.id,
         name=item.name,
         created=item.created,
@@ -63,4 +67,6 @@ def for_sync_slack_conversation_item_repr(
         is_shared=item.is_shared,
         topic=topic,
         updated=item.updated,
+        updated_at=item.updated_at,
+        created_at=item.created_at,
     )

--- a/src/application/repr/__init__.py
+++ b/src/application/repr/__init__.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
-from src.domain.models import SlackEvent
+
+from src.domain.models import ForSyncSlackConversationItem, SlackEvent
 
 
 class TenantRepr(BaseModel):
@@ -9,10 +10,57 @@ class TenantRepr(BaseModel):
 
 
 class SlackCallBackEventRepr(BaseModel):
-    pass
+    id: str
 
 
-def slack_callback_event_repr_factory(
+class InSyncSlackConversationItemRepr(BaseModel):
+    id: str
+    name: str
+    created: int
+    is_archived: bool
+    is_channel: bool
+    is_ext_shared: bool
+    is_general: bool
+    is_group: bool
+    is_im: bool
+    is_member: bool
+    is_mpim: bool
+    is_org_shared: bool
+    is_pending_ext_shared: bool
+    is_private: bool
+    is_shared: bool
+    topic: dict
+    updated: int
+
+
+def slack_callback_event_repr(
     slack_event: SlackEvent,
 ) -> SlackCallBackEventRepr:
     pass
+
+
+def for_sync_slack_conversation_item_repr(
+    item: ForSyncSlackConversationItem,
+) -> InSyncSlackConversationItemRepr:
+    topic = {
+        "value": item.topic.get("value", ""),
+    }
+    return InSyncSlackConversationItemRepr(
+        id=item.id,
+        name=item.name,
+        created=item.created,
+        is_archived=item.is_archived,
+        is_channel=item.is_channel,
+        is_ext_shared=item.is_ext_shared,
+        is_general=item.is_general,
+        is_group=item.is_group,
+        is_im=item.is_im,
+        is_member=item.is_member,
+        is_mpim=item.is_mpim,
+        is_org_shared=item.is_org_shared,
+        is_pending_ext_shared=item.is_pending_ext_shared,
+        is_private=item.is_private,
+        is_shared=item.is_shared,
+        topic=topic,
+        updated=item.updated,
+    )

--- a/src/domain/exceptions.py
+++ b/src/domain/exceptions.py
@@ -1,0 +1,6 @@
+class TenantValueError(ValueError):
+    pass
+
+
+class SlackChannelReferenceValueError(ValueError):
+    pass

--- a/src/domain/models/__init__.py
+++ b/src/domain/models/__init__.py
@@ -1,4 +1,5 @@
 import abc
+from datetime import datetime
 from enum import Enum
 
 from attrs import define, field
@@ -245,46 +246,16 @@ class SlackEvent(AbstractEntity):
         return token
 
 
-# {
-#     "context_team_id": "T03NX4VMCRH",
-#     "created": 1691054861,
-#     "creator": "U03NGJTT5JT",
-#     "id": "C05L4282G03",
-#     "is_archived": False,
-#     "is_channel": True,
-#     "is_ext_shared": False,
-#     "is_general": False,
-#     "is_group": False,
-#     "is_im": False,
-#     "is_member": False,
-#     "is_mpim": False,
-#     "is_org_shared": False,
-#     "is_pending_ext_shared": False,
-#     "is_private": False,
-#     "is_shared": False,
-#     "name": "ext-foobar",
-#     "name_normalized": "ext-foobar",
-#     "num_members": 1,
-#     "parent_conversation": None,
-#     "pending_connected_team_ids": [],
-#     "pending_shared": [],
-#     "previous_names": [],
-#     "purpose": {"creator": "", "last_set": 0, "value": ""},
-#     "shared_team_ids": ["T03NX4VMCRH"],
-#     "topic": {"creator": "", "last_set": 0, "value": ""},
-#     "unlinked": 0,
-#     "updated": 1691054861992,
-# }
-
-
 @define
-class ForSyncSlackConversationItem(AbstractValueObject):
+class InSyncSlackChannelItem(AbstractValueObject):
     """
     Represents a Slack conversation item, after succesful API call.
+    We call it Slack Channel for our understandings.
     Attrs:
         as defined in https://api.slack.com/types/conversation
     """
 
+    tenant_id: str
     context_team_id: str
     created: int = field(eq=False)
     creator: str
@@ -314,9 +285,13 @@ class ForSyncSlackConversationItem(AbstractValueObject):
     unlinked: int = field(eq=False)
     updated: int = field(eq=False)
 
+    updated_at: datetime | None = None
+    created_at: datetime | None = None
+
     @classmethod
-    def from_dict(cls, data: dict) -> "ForSyncSlackConversationItem":
+    def from_dict(cls, tenant_id, data: dict) -> "InSyncSlackChannelItem":
         return cls(
+            tenant_id=tenant_id,
             context_team_id=data.get("context_team_id"),
             created=data.get("created"),
             creator=data.get("creator"),

--- a/src/domain/models/__init__.py
+++ b/src/domain/models/__init__.py
@@ -18,51 +18,6 @@ class AbstractValueObject:
     pass
 
 
-# deprecate
-class SlackCallbackEvent(AbstractEntity):
-    """
-    Represents a Slack callback event.
-
-    Attributes:
-        event_id (str): The unique identifier for the event.
-        team_id (str): The unique identifier for the team.
-        event_type (str): The type of event.
-        event (dict): The event payload.
-        event_ts (int, optional): The event time stamp from Slack.
-        metadata (dict, optional): Other metadata from Slack.
-    """
-
-    def __init__(
-        self,
-        event_id: str,
-        team_id: str,
-        event_type: str,
-        event: dict,
-        event_ts: int,
-        metadata: dict | None = None,
-        is_ack: bool = False,
-    ) -> None:
-        self.event_id = event_id
-        self.team_id = team_id
-        self.event_type = event_type
-        self.event = event
-        self.event_ts = event_ts  # event time stamp from Slack
-        self.metadata = metadata  # other metadata from Slack
-        self.is_ack = is_ack  # whether the event was acknowledged
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, SlackCallbackEvent):
-            return False
-        return self.event_id == other.event_id
-
-    def __repr__(self) -> str:
-        return f"""SlackCallbackEvent(
-                event_id={self.event_id},
-                team_id={self.team_id},
-                event_type={self.event_type}
-            )"""
-
-
 class Tenant(AbstractEntity):
     def __init__(self, tenant_id: str | None, name: str) -> None:
         self.tenant_id = tenant_id
@@ -288,3 +243,106 @@ class SlackEvent(AbstractEntity):
     def token(self) -> str | None:
         token = self.payload.get("token", None)
         return token
+
+
+# {
+#     "context_team_id": "T03NX4VMCRH",
+#     "created": 1691054861,
+#     "creator": "U03NGJTT5JT",
+#     "id": "C05L4282G03",
+#     "is_archived": False,
+#     "is_channel": True,
+#     "is_ext_shared": False,
+#     "is_general": False,
+#     "is_group": False,
+#     "is_im": False,
+#     "is_member": False,
+#     "is_mpim": False,
+#     "is_org_shared": False,
+#     "is_pending_ext_shared": False,
+#     "is_private": False,
+#     "is_shared": False,
+#     "name": "ext-foobar",
+#     "name_normalized": "ext-foobar",
+#     "num_members": 1,
+#     "parent_conversation": None,
+#     "pending_connected_team_ids": [],
+#     "pending_shared": [],
+#     "previous_names": [],
+#     "purpose": {"creator": "", "last_set": 0, "value": ""},
+#     "shared_team_ids": ["T03NX4VMCRH"],
+#     "topic": {"creator": "", "last_set": 0, "value": ""},
+#     "unlinked": 0,
+#     "updated": 1691054861992,
+# }
+
+
+@define
+class ForSyncSlackConversationItem(AbstractValueObject):
+    """
+    Represents a Slack conversation item, after succesful API call.
+    Attrs:
+        as defined in https://api.slack.com/types/conversation
+    """
+
+    context_team_id: str
+    created: int = field(eq=False)
+    creator: str
+    id: str
+    is_archived: bool
+    is_channel: bool
+    is_ext_shared: bool
+    is_general: bool
+    is_group: bool
+    is_im: bool
+    is_member: bool
+    is_mpim: bool
+    is_org_shared: bool
+    is_pending_ext_shared: bool
+    is_private: bool
+    is_shared: bool
+    name: str = field(eq=False)
+    name_normalized: str = field(eq=False)
+    num_members: int = field(eq=False)
+    parent_conversation: str | None = field(eq=False)
+    pending_connected_team_ids: list[str] = field(eq=False)
+    pending_shared: list[str] = field(eq=False)
+    previous_names: list[str] = field(eq=False)
+    purpose: dict[str, str] = field(eq=False)
+    shared_team_ids: list[str] = field(eq=False)
+    topic: dict[str, str] = field(eq=False)
+    unlinked: int = field(eq=False)
+    updated: int = field(eq=False)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ForSyncSlackConversationItem":
+        return cls(
+            context_team_id=data.get("context_team_id"),
+            created=data.get("created"),
+            creator=data.get("creator"),
+            id=data.get("id"),
+            is_archived=data.get("is_archived"),
+            is_channel=data.get("is_channel"),
+            is_ext_shared=data.get("is_ext_shared"),
+            is_general=data.get("is_general"),
+            is_group=data.get("is_group"),
+            is_im=data.get("is_im"),
+            is_member=data.get("is_member"),
+            is_mpim=data.get("is_mpim"),
+            is_org_shared=data.get("is_org_shared"),
+            is_pending_ext_shared=data.get("is_pending_ext_shared"),
+            is_private=data.get("is_private"),
+            is_shared=data.get("is_shared"),
+            name=data.get("name"),
+            name_normalized=data.get("name_normalized"),
+            num_members=data.get("num_members"),
+            parent_conversation=data.get("parent_conversation"),
+            pending_connected_team_ids=data.get("pending_connected_team_ids"),
+            pending_shared=data.get("pending_shared"),
+            previous_names=data.get("previous_names"),
+            purpose=data.get("purpose"),
+            shared_team_ids=data.get("shared_team_ids"),
+            topic=data.get("topic"),
+            unlinked=data.get("unlinked"),
+            updated=data.get("updated"),
+        )

--- a/src/services/channel/__init__.py
+++ b/src/services/channel/__init__.py
@@ -1,0 +1,47 @@
+from src.adapters.db.adapters import (
+    InSyncChannelDBAdapter,
+    LinkedSlackChannelDBAdapter,
+    TenantDBAdapter,
+)
+from src.application.commands import LinkSlackChannelCommand
+from src.domain.models import LinkedSlackChannel, TriageSlackChannel
+
+
+class ChannelLinkService:
+    def __init__(self) -> None:
+        self.tenant_db = TenantDBAdapter()
+        self.insync_channel_db = InSyncChannelDBAdapter()
+        self.linked_slack_channel_db = LinkedSlackChannelDBAdapter()
+
+    async def link(self, command: LinkSlackChannelCommand):
+        tenant = await self.tenant_db.get_by_id(command.tenant_id)
+
+        insync_slack_channel = (
+            await self.insync_channel_db.get_by_tenant_id_slack_channel_ref(
+                tenant_id=command.tenant_id, slack_channel_ref=command.slack_channel_ref
+            )
+        )
+        insync_slack_channel_for_triage = (
+            await self.insync_channel_db.get_by_tenant_id_slack_channel_ref(
+                tenant_id=command.tenant_id,
+                slack_channel_ref=command.triage_slack_channel_ref,
+            )
+        )
+        triage_slack_channel = TriageSlackChannel(
+            tenant_id=tenant.tenant_id,
+            slack_channel_ref=insync_slack_channel_for_triage.id,
+            slack_channel_name=insync_slack_channel_for_triage.name,
+        )
+
+        linked_slack_channel = LinkedSlackChannel(
+            tenant_id=tenant.tenant_id,
+            linked_slack_channel_id=None,
+            slack_channel_ref=insync_slack_channel.id,
+            slack_channel_name=insync_slack_channel.name,
+        )
+        linked_slack_channel.add_triage_channel(triage_slack_channel)
+
+        linked_slack_channel = await self.linked_slack_channel_db.save(
+            linked_slack_channel
+        )
+        return linked_slack_channel

--- a/src/services/event/__init__.py
+++ b/src/services/event/__init__.py
@@ -13,6 +13,7 @@ class SlackEventCallBackDispatchService:
     async def _capture(self, slack_event: SlackEvent) -> None:
         slack_event = await self.slack_event_db.save(slack_event)
         logger.info('captured slack event: "%s"', slack_event)
+        return slack_event
 
     async def _dispatch(self, slack_event: SlackEvent) -> None:
         raise NotImplementedError
@@ -46,7 +47,7 @@ class SlackEventCallBackDispatchService:
                 + "is not mapped to a tenant or is invalid."
             )
 
-        slack_event = SlackEvent.init_from_payload(
+        slack_event = SlackEvent.from_payload(
             tenant_id=tenant.tenant_id, payload=command.payload
         )
 
@@ -54,10 +55,10 @@ class SlackEventCallBackDispatchService:
             command.slack_event_ref
         )
 
-        if slack_event.equals_by_slack_event_ref(captured_slack_event):
+        if captured_slack_event.equals_by_slack_event_ref(slack_event):
             logger.warning(
-                'slack event already captured: "%s". skipping dispactching.',
-                slack_event,
+                'slack event already captured: "%s" skipping dispatch.',
+                captured_slack_event,
             )
             return captured_slack_event
 

--- a/src/services/tenant/__init__.py
+++ b/src/services/tenant/__init__.py
@@ -1,7 +1,10 @@
-from src.adapters.db.adapters import TenantDBAdapter
+from src.adapters.db.adapters import InSyncChannelDBAdapter, TenantDBAdapter
 from src.adapters.rpc.ext import SlackWebAPIConnector
-from src.application.commands import TenantProvisionCommand
+from src.application.commands import TenantProvisionCommand, TenantSyncChannelCommand
 from src.application.exceptions import SlackTeamRefMapException
+
+# TODO: later this will be fetched from tenant context, and will be removed.
+from src.config import SLACK_BOT_OAUTH_TOKEN
 from src.domain.models import Tenant
 from src.logger import logger
 
@@ -35,19 +38,32 @@ class TenantProvisionService:
 class TenantChannelSyncService:
     def __init__(self) -> None:
         self.tenant_db = TenantDBAdapter()
-        self.slack_api = SlackWebAPIConnector()
+        self.insync_channel_db = InSyncChannelDBAdapter()
 
-    def sync_with_sync(self, types=None):
+    async def sync_now(self, command: TenantSyncChannelCommand):
+        """
+        sync channels with synchronous approach
+        """
+        types = command.types
         if types is None:
             types = ["public_channel"]
-        """
-        sync channels with syncronous approach
-        """
-        results = self.slack_api.get_conversation_list(",".join([t for t in types]))
-        return results
 
-    def sync_with_async(self):
+        tenant = await self.tenant_db.get_by_id(command.tenant_id)
+        logger.info(f"sync channels for tenant with tenant context: `{tenant}`")
+
+        slack_api = SlackWebAPIConnector.for_tenant(
+            tenant=tenant,
+            token=SLACK_BOT_OAUTH_TOKEN,  # TODO: disable this later when we can read token from tenant context # noqa
+        )
+        results = slack_api.get_conversation_list(",".join([t for t in types]))
+        saved_results = []
+        for result in results:
+            saved_result = await self.insync_channel_db.save(result)
+            saved_results.append(saved_result)
+        return saved_results
+
+    def sync_task(self):
         """
-        sync channels with asyncronous approach
+        sync channels with asynchronous approach
         """
-        pass
+        raise NotImplementedError

--- a/src/services/tenant/__init__.py
+++ b/src/services/tenant/__init__.py
@@ -1,4 +1,5 @@
 from src.adapters.db.adapters import TenantDBAdapter
+from src.adapters.rpc.ext import SlackWebAPIConnector
 from src.application.commands import TenantProvisionCommand
 from src.application.exceptions import SlackTeamRefMapException
 from src.domain.models import Tenant
@@ -29,3 +30,24 @@ class TenantProvisionService:
         tenant.set_slack_team_ref(command.slack_team_ref)
         tenant = await self.tenant_db.save(tenant)
         return tenant
+
+
+class TenantChannelSyncService:
+    def __init__(self) -> None:
+        self.tenant_db = TenantDBAdapter()
+        self.slack_api = SlackWebAPIConnector()
+
+    def sync_with_sync(self, types=None):
+        if types is None:
+            types = ["public_channel"]
+        """
+        sync channels with syncronous approach
+        """
+        results = self.slack_api.get_conversation_list(",".join([t for t in types]))
+        return results
+
+    def sync_with_async(self):
+        """
+        sync channels with asyncronous approach
+        """
+        pass


### PR DESCRIPTION
API router for linking the slack channel and corresponding triage channel and created services for linking the slack channel. Added checks to ensure the linking and triage channels are different. New DB adapter and DB repository for persisting linked slack channel state. I also added a new SQL table, `linked_slack_channel` for persisting in SQL DB.

Yet to implement exception handling.